### PR TITLE
destroyStringParams: set owned = false after free

### DIFF
--- a/src/napi/transaction.cpp
+++ b/src/napi/transaction.cpp
@@ -116,7 +116,10 @@ static napi_status toStringParams(napi_env env, napi_value value, StringParams *
 }
 
 static void destroyStringParams(StringParams *params) {
-  if (params->owned) free(params->str);
+  if (params->owned) {
+    free(params->str);
+    params->owned = false;
+  }
   else if (params->str == sp_buf) buf_in_use = false;
   params->str = NULL;
 }


### PR DESCRIPTION
Hello -- I was hitting the following assert:

https://github.com/josephg/node-foundationdb/blob/e0006e4d28a6c42be9003e847f5063a3442b7a1f/src/napi/transaction.cpp#L72

Please let me know if this patch is the right way to go.

Thanks.