### PR TITLE
Add support for `exactOptionalPropertyTypes` TypeScript option

### DIFF
--- a/lib/directory.ts
+++ b/lib/directory.ts
@@ -500,16 +500,16 @@ export class Directory<KeyIn = NativeValue, KeyOut = Buffer, ValIn = NativeValue
 
 interface DirectoryLayerOpts {
   /** The prefix for directory metadata nodes. Defaults to '\xfe' */
-  nodePrefix?: string | Buffer
+  nodePrefix?: undefined | string | Buffer
   // We really actually want a NodeSubspace here, but we'll set the kv encoding
   // ourselves to make the API simpler.
-  nodeSubspace?: SubspaceAny
-  
-  /** The prefix for content. Defaults to ''. */
-  contentPrefix?: string | Buffer // Defaults to '', the root.
-  contentSubspace?: SubspaceAny
+  nodeSubspace?: undefined | SubspaceAny
 
-  allowManualPrefixes?: boolean // default false
+  /** The prefix for content. Defaults to ''. */
+  contentPrefix?: undefined | string | Buffer // Defaults to '', the root.
+  contentSubspace?: undefined | SubspaceAny
+
+  allowManualPrefixes?: undefined | boolean // default false
 }
 
 export class DirectoryLayer {

--- a/lib/opts.g.ts
+++ b/lib/opts.g.ts
@@ -2,51 +2,51 @@
 import {OptionData} from './opts'
 
 export type NetworkOptions = {
-  local_address?: string // DEPRECATED
-  cluster_file?: string // DEPRECATED
-  trace_enable?: string  // path to output directory (or NULL for current working directory)
-  trace_roll_size?: number  // max size of a single trace output file
-  trace_max_logs_size?: number  // max total size of trace files
-  trace_log_group?: string  // value of the LogGroup attribute
-  trace_format?: string  // Format of trace files
-  trace_clock_source?: string  // Trace clock source
-  trace_file_identifier?: string  // The identifier that will be part of all trace file names
-  trace_share_among_client_threads?: true
-  trace_partial_file_suffix?: string  // Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix. No separator is added between the file and the suffix. If you want to add a file extension, you should include the separator - e.g. '.tmp' instead of 'tmp' to add the 'tmp' extension.
-  knob?: string  // knob_name=knob_value
-  TLS_plugin?: string // DEPRECATED
-  TLS_cert_bytes?: Buffer  // certificates
-  TLS_cert_path?: string  // file path
-  TLS_key_bytes?: Buffer  // key
-  TLS_key_path?: string  // file path
-  TLS_verify_peers?: Buffer  // verification pattern
-  Buggify_enable?: true
-  Buggify_disable?: true
-  Buggify_section_activated_probability?: number  // probability expressed as a percentage between 0 and 100
-  Buggify_section_fired_probability?: number  // probability expressed as a percentage between 0 and 100
-  TLS_ca_bytes?: Buffer  // ca bundle
-  TLS_ca_path?: string  // file path
-  TLS_password?: string  // key passphrase
-  disable_multi_version_client_api?: true
-  callbacks_on_external_threads?: true
-  external_client_library?: string  // path to client library
-  external_client_directory?: string  // path to directory containing client libraries
-  disable_local_client?: true
-  client_threads_per_version?: number  // Number of client threads to be spawned.  Each cluster will be serviced by a single client thread.
-  future_version_client_library?: string  // path to client library
-  disable_client_statistics_logging?: true
-  enable_slow_task_profiling?: true // DEPRECATED
-  enable_run_loop_profiling?: true
-  disable_client_bypass?: true
-  client_buggify_enable?: true
-  client_buggify_disable?: true
-  client_buggify_section_activated_probability?: number  // probability expressed as a percentage between 0 and 100
-  client_buggify_section_fired_probability?: number  // probability expressed as a percentage between 0 and 100
-  distributed_client_tracer?: string  // Distributed tracer type. Choose from none, log_file, or network_lossy
-  client_tmp_dir?: string  // Client directory for temporary files. 
-  supported_client_versions?: string  // [release version],[source version],[protocol version];...
-  external_client?: true
-  external_client_transport_id?: number  // Transport ID for the child connection
+  local_address?: undefined | string // DEPRECATED
+  cluster_file?: undefined | string // DEPRECATED
+  trace_enable?: undefined | string  // path to output directory (or NULL for current working directory)
+  trace_roll_size?: undefined | number  // max size of a single trace output file
+  trace_max_logs_size?: undefined | number  // max total size of trace files
+  trace_log_group?: undefined | string  // value of the LogGroup attribute
+  trace_format?: undefined | string  // Format of trace files
+  trace_clock_source?: undefined | string  // Trace clock source
+  trace_file_identifier?: undefined | string  // The identifier that will be part of all trace file names
+  trace_share_among_client_threads?: undefined | true
+  trace_partial_file_suffix?: undefined | string  // Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix. No separator is added between the file and the suffix. If you want to add a file extension, you should include the separator - e.g. '.tmp' instead of 'tmp' to add the 'tmp' extension.
+  knob?: undefined | string  // knob_name=knob_value
+  TLS_plugin?: undefined | string // DEPRECATED
+  TLS_cert_bytes?: undefined | Buffer  // certificates
+  TLS_cert_path?: undefined | string  // file path
+  TLS_key_bytes?: undefined | Buffer  // key
+  TLS_key_path?: undefined | string  // file path
+  TLS_verify_peers?: undefined | Buffer  // verification pattern
+  Buggify_enable?: undefined | true
+  Buggify_disable?: undefined | true
+  Buggify_section_activated_probability?: undefined | number  // probability expressed as a percentage between 0 and 100
+  Buggify_section_fired_probability?: undefined | number  // probability expressed as a percentage between 0 and 100
+  TLS_ca_bytes?: undefined | Buffer  // ca bundle
+  TLS_ca_path?: undefined | string  // file path
+  TLS_password?: undefined | string  // key passphrase
+  disable_multi_version_client_api?: undefined | true
+  callbacks_on_external_threads?: undefined | true
+  external_client_library?: undefined | string  // path to client library
+  external_client_directory?: undefined | string  // path to directory containing client libraries
+  disable_local_client?: undefined | true
+  client_threads_per_version?: undefined | number  // Number of client threads to be spawned.  Each cluster will be serviced by a single client thread.
+  future_version_client_library?: undefined | string  // path to client library
+  disable_client_statistics_logging?: undefined | true
+  enable_slow_task_profiling?: undefined | true // DEPRECATED
+  enable_run_loop_profiling?: undefined | true
+  disable_client_bypass?: undefined | true
+  client_buggify_enable?: undefined | true
+  client_buggify_disable?: undefined | true
+  client_buggify_section_activated_probability?: undefined | number  // probability expressed as a percentage between 0 and 100
+  client_buggify_section_fired_probability?: undefined | number  // probability expressed as a percentage between 0 and 100
+  distributed_client_tracer?: undefined | string  // Distributed tracer type. Choose from none, log_file, or network_lossy
+  client_tmp_dir?: undefined | string  // Client directory for temporary files. 
+  supported_client_versions?: undefined | string  // [release version],[source version],[protocol version];...
+  external_client?: undefined | true
+  external_client_transport_id?: undefined | number  // Transport ID for the child connection
 }
 
 export enum NetworkOptionCode {
@@ -310,23 +310,23 @@ export enum NetworkOptionCode {
 }
 
 export type DatabaseOptions = {
-  location_cache_size?: number  // Max location cache entries
-  max_watches?: number  // Max outstanding watches
-  machine_id?: string  // Hexadecimal ID
-  datacenter_id?: string  // Hexadecimal ID
-  snapshot_ryw_enable?: true
-  snapshot_ryw_disable?: true
-  transaction_logging_max_field_length?: number  // Maximum length of escaped key and value fields.
-  transaction_timeout?: number  // value in milliseconds of timeout
-  transaction_retry_limit?: number  // number of times to retry
-  transaction_max_retry_delay?: number  // value in milliseconds of maximum delay
-  transaction_size_limit?: number  // value in bytes
-  transaction_causal_read_risky?: true
-  transaction_include_port_in_address?: true
-  transaction_automatic_idempotency?: true
-  transaction_bypass_unreadable?: true
-  use_config_database?: true
-  test_causal_read_risky?: true
+  location_cache_size?: undefined | number  // Max location cache entries
+  max_watches?: undefined | number  // Max outstanding watches
+  machine_id?: undefined | string  // Hexadecimal ID
+  datacenter_id?: undefined | string  // Hexadecimal ID
+  snapshot_ryw_enable?: undefined | true
+  snapshot_ryw_disable?: undefined | true
+  transaction_logging_max_field_length?: undefined | number  // Maximum length of escaped key and value fields.
+  transaction_timeout?: undefined | number  // value in milliseconds of timeout
+  transaction_retry_limit?: undefined | number  // number of times to retry
+  transaction_max_retry_delay?: undefined | number  // value in milliseconds of maximum delay
+  transaction_size_limit?: undefined | number  // value in bytes
+  transaction_causal_read_risky?: undefined | true
+  transaction_include_port_in_address?: undefined | true
+  transaction_automatic_idempotency?: undefined | true
+  transaction_bypass_unreadable?: undefined | true
+  use_config_database?: undefined | true
+  test_causal_read_risky?: undefined | true
 }
 
 export enum DatabaseOptionCode {
@@ -457,55 +457,55 @@ export enum DatabaseOptionCode {
 }
 
 export type TransactionOptions = {
-  causal_write_risky?: true
-  causal_read_risky?: true
-  causal_read_disable?: true
-  include_port_in_address?: true
-  next_write_no_write_conflict_range?: true
-  commit_on_first_proxy?: true
-  check_writes_enable?: true
-  read_your_writes_disable?: true
-  read_ahead_disable?: true // DEPRECATED
-  durability_datacenter?: true
-  durability_risky?: true
-  durability_dev_null_is_web_scale?: true // DEPRECATED
-  priority_system_immediate?: true
-  priority_batch?: true
-  initialize_new_database?: true
-  access_system_keys?: true
-  read_system_keys?: true
-  raw_access?: true
-  debug_dump?: true
-  debug_retry_logging?: string  // Optional transaction name
-  transaction_logging_enable?: string // DEPRECATED
-  debug_transaction_identifier?: string  // String identifier to be used when tracing or profiling this transaction. The identifier must not exceed 100 characters.
-  log_transaction?: true
-  transaction_logging_max_field_length?: number  // Maximum length of escaped key and value fields.
-  server_request_tracing?: true
-  timeout?: number  // value in milliseconds of timeout
-  retry_limit?: number  // number of times to retry
-  max_retry_delay?: number  // value in milliseconds of maximum delay
-  size_limit?: number  // value in bytes
-  idempotency_id?: string  // Unique ID
-  automatic_idempotency?: true
-  snapshot_ryw_enable?: true
-  snapshot_ryw_disable?: true
-  lock_aware?: true
-  used_during_commit_protection_disable?: true
-  read_lock_aware?: true
-  first_in_batch?: true
-  use_provisional_proxies?: true
-  report_conflicting_keys?: true
-  special_key_space_relaxed?: true
-  special_key_space_enable_writes?: true
-  tag?: string  // String identifier used to associated this transaction with a throttling group. Must not exceed 16 characters.
-  auto_throttle_tag?: string  // String identifier used to associated this transaction with a throttling group. Must not exceed 16 characters.
-  span_parent?: Buffer  // A byte string of length 16 used to associate the span of this transaction with a parent
-  expensive_clear_cost_estimation_enable?: true
-  bypass_unreadable?: true
-  use_grv_cache?: true
-  skip_grv_cache?: true
-  authorization_token?: string  // A JSON Web Token authorized to access data belonging to one or more tenants, indicated by 'tenants' claim of the token's payload.
+  causal_write_risky?: undefined | true
+  causal_read_risky?: undefined | true
+  causal_read_disable?: undefined | true
+  include_port_in_address?: undefined | true
+  next_write_no_write_conflict_range?: undefined | true
+  commit_on_first_proxy?: undefined | true
+  check_writes_enable?: undefined | true
+  read_your_writes_disable?: undefined | true
+  read_ahead_disable?: undefined | true // DEPRECATED
+  durability_datacenter?: undefined | true
+  durability_risky?: undefined | true
+  durability_dev_null_is_web_scale?: undefined | true // DEPRECATED
+  priority_system_immediate?: undefined | true
+  priority_batch?: undefined | true
+  initialize_new_database?: undefined | true
+  access_system_keys?: undefined | true
+  read_system_keys?: undefined | true
+  raw_access?: undefined | true
+  debug_dump?: undefined | true
+  debug_retry_logging?: undefined | string  // Optional transaction name
+  transaction_logging_enable?: undefined | string // DEPRECATED
+  debug_transaction_identifier?: undefined | string  // String identifier to be used when tracing or profiling this transaction. The identifier must not exceed 100 characters.
+  log_transaction?: undefined | true
+  transaction_logging_max_field_length?: undefined | number  // Maximum length of escaped key and value fields.
+  server_request_tracing?: undefined | true
+  timeout?: undefined | number  // value in milliseconds of timeout
+  retry_limit?: undefined | number  // number of times to retry
+  max_retry_delay?: undefined | number  // value in milliseconds of maximum delay
+  size_limit?: undefined | number  // value in bytes
+  idempotency_id?: undefined | string  // Unique ID
+  automatic_idempotency?: undefined | true
+  snapshot_ryw_enable?: undefined | true
+  snapshot_ryw_disable?: undefined | true
+  lock_aware?: undefined | true
+  used_during_commit_protection_disable?: undefined | true
+  read_lock_aware?: undefined | true
+  first_in_batch?: undefined | true
+  use_provisional_proxies?: undefined | true
+  report_conflicting_keys?: undefined | true
+  special_key_space_relaxed?: undefined | true
+  special_key_space_enable_writes?: undefined | true
+  tag?: undefined | string  // String identifier used to associated this transaction with a throttling group. Must not exceed 16 characters.
+  auto_throttle_tag?: undefined | string  // String identifier used to associated this transaction with a throttling group. Must not exceed 16 characters.
+  span_parent?: undefined | Buffer  // A byte string of length 16 used to associate the span of this transaction with a parent
+  expensive_clear_cost_estimation_enable?: undefined | true
+  bypass_unreadable?: undefined | true
+  use_grv_cache?: undefined | true
+  skip_grv_cache?: undefined | true
+  authorization_token?: undefined | string  // A JSON Web Token authorized to access data belonging to one or more tenants, indicated by 'tenants' claim of the token's payload.
 }
 
 export enum TransactionOptionCode {

--- a/lib/transaction.ts
+++ b/lib/transaction.ts
@@ -39,13 +39,13 @@ byteZero.writeUInt8(0, 0)
 
 export interface RangeOptionsBatch {
   // defaults to Iterator for batch mode, WantAll for getRangeAll.
-  streamingMode?: StreamingMode,
-  limit?: number,
-  reverse?: boolean,
+  streamingMode?: undefined | StreamingMode,
+  limit?: undefined | number,
+  reverse?: undefined | boolean,
 }
 
 export interface RangeOptions extends RangeOptionsBatch {
-  targetBytes?: number,
+  targetBytes?: undefined | number,
 }
 
 export type KVList<Key, Value> = {
@@ -56,7 +56,7 @@ export type KVList<Key, Value> = {
 export {Watch}
 
 export type WatchOptions = {
-  throwAllErrors?: boolean
+  throwAllErrors?: undefined | boolean
 }
 
 // Polyfill for node < 10.0 to make asyncIterators work (getRange / getRangeBatch).
@@ -752,7 +752,15 @@ export default class Transaction<KeyIn = NativeValue, KeyOut = Buffer, ValIn = N
    */
   async getVersionstampPrefixedValue(key: KeyIn): Promise<{stamp: Buffer, value?: ValOut} | null> {
     const val = await this._tn.get(this._keyEncoding.pack(key), this.isSnapshot)
-    return val == null ? null
+
+    if (val == null) {
+      return null;
+    }
+
+    return val.length <= 10
+      ? {
+        stamp: val
+      }
       : {
         stamp: val.slice(0, 10),
 
@@ -762,7 +770,7 @@ export default class Transaction<KeyIn = NativeValue, KeyOut = Buffer, ValIn = N
         // for the decoder and that can cause issues. We'll just return null
         // in that case - but, yeah, controversial. You might want some other
         // encoding or something. File an issue if this causes you grief.
-        value: val.length > 10 ? this._valueEncoding.unpack(val.slice(10)) : undefined
+        value: this._valueEncoding.unpack(val.slice(10))
       }
   }
 

--- a/scripts/gentsopts.ts
+++ b/scripts/gentsopts.ts
@@ -68,7 +68,7 @@ parseString(xml, (err, result) => {
     if (name.endsWith('Option')) {
       line(`export type ${name}s = {`)
       options.forEach(({name, type, paramDescription, deprecated}) => {
-        output.write(`  ${name}?: ${typeToTs(type)}`)
+        output.write(`  ${name}?: undefined | ${typeToTs(type)}`)
         if (deprecated) output.write(` ${comment} DEPRECATED`)
         else if (paramDescription) output.write(`  ${comment} ${paramDescription}`)
         line()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,55 +6,13 @@
     "target": "ES2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["esnext"],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./lib",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "stripInternal": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
TypeScript 4.4 introduced `exactOptionalPropertyTypes` compiler option. This fixed one of the major issues I had with TypeScript and, I think, should be the default in all new projects. It avoids unnecessary checks and type assertions/casts, improving type safety. But it also means that all optional object field types in the project, including those from third-party libraries, have to explicitly include `undefined` to preserve the old behavior.

This PR is mostly just convenience, so I could do
```js
function foo(reverse?: boolean) {
	return tn.getRange('', '\xff', { reverse });
}
```
instead of
```js
function foo(reverse?: boolean) {
	return tn.getRange('', '\xff', reverse != null ? { reverse } : {});
}
```

This PR:
 - Adds `undefined` to optional object field types where applicable (which is most of them).
 - Adds `exactOptionalPropertyTypes: true` to TypeScript configuration.
 - Removes boilerplate from `tsconfig.json` because it's weird to add options with the boilerplate in the way.

While I'm at it, would that be ok to do some maintenance tasks too? Like:
 - Fix excess whitespaces at the end of lines. Most development environments should do this automatically, so excess whitespaces cause some pain.
 - Fix trailing new lines to make Git and other tools happy. Again, most development environments should do this automatically.
 - Update dependencies
 - Possibly add a basic ESLint setup