### PR TITLE
Fix memory leaks in watch and callback API-s

### DIFF
--- a/src/future.cpp
+++ b/src/future.cpp
@@ -181,6 +181,7 @@ MaybeValue fdbFutureToCallback(napi_env env, FDBFuture *f, napi_value cbFunc, Ex
     napi_value callback;
     NAPI_OK_OR_RETURN_STATUS(env, napi_get_reference_value(env, ctx->cbFunc, &callback));
     NAPI_OK_OR_RETURN_STATUS(env, napi_reference_unref(env, ctx->cbFunc, NULL));
+    NAPI_OK_OR_RETURN_STATUS(env, napi_delete_reference(env, ctx->cbFunc));
 
     size_t argc = 1; // In case of error we just won't populate argv[1].
     napi_value argv[2] = {}; // (err, value).
@@ -306,6 +307,7 @@ MaybeValue watchFuture(napi_env env, FDBFuture *f, bool ignoreStandardErrors) {
     napi_value jsWatch;
     NAPI_OK_OR_RETURN_STATUS(env, napi_get_reference_value(env, ctx->jsWatch, &jsWatch));
     NAPI_OK_OR_RETURN_STATUS(env, napi_reference_unref(env, ctx->jsWatch, NULL));
+    NAPI_OK_OR_RETURN_STATUS(env, napi_delete_reference(env, ctx->jsWatch));
 
     // Unlink the handle to the future.
     NAPI_OK_OR_RETURN_STATUS(env, napi_remove_wrap(env, jsWatch, NULL));


### PR DESCRIPTION
Resolves #82

Apparently, the references created in `watchFuture` and `fdbFutureToCallback` have to be deleted explicitly in addition to being unref-ed. Just deleting wouldn't be enough either. After applying this patch, the memory usage seems to eventually flatline and Valgrind is reasonably happy.

From [Node-API doc](https://nodejs.org/api/n-api.html#references-to-values-with-a-lifespan-longer-than-that-of-the-native-method):

> References must be deleted once they are no longer required by the addon. When a reference is deleted, it will no longer prevent the corresponding object from being collected. Failure to delete a persistent reference results in a 'memory leak' with both the native memory for the persistent reference and the corresponding object on the heap being retained forever.

