### PR TITLE
update apiVersion from 720 to 730

### DIFF
--- a/.github/workflows/buildmod.yml
+++ b/.github/workflows/buildmod.yml
@@ -20,11 +20,11 @@ jobs:
       with:
         node-version: 18
 
-    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-clients_7.2.5-1_amd64.deb"
-    - run: sudo dpkg -i foundationdb-clients_7.2.5-1_amd64.deb
+    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-clients_7.3.59-1_amd64.deb"
+    - run: sudo dpkg -i foundationdb-clients_7.3.59-1_amd64.deb
     - run: sudo mkdir -p /var/lib/foundationdb/data
-    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-server_7.2.5-1_amd64.deb"
-    - run: sudo dpkg -i foundationdb-server_7.2.5-1_amd64.deb
+    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-server_7.3.59-1_amd64.deb"
+    - run: sudo dpkg -i foundationdb-server_7.3.59-1_amd64.deb
 
     - run: yarn
     - run: yarn prebuild
@@ -48,8 +48,8 @@ jobs:
         node-version: 14
 
     # x86 first.
-    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.2.5/FoundationDB-7.2.5_x86_64.pkg"
-    - run: sudo installer -pkg FoundationDB-7.2.5_x86_64.pkg -target /
+    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.3.59/FoundationDB-7.3.59_x86_64.pkg"
+    - run: sudo installer -pkg FoundationDB-7.3.59_x86_64.pkg -target /
 
     - run: yarn
     - run: yarn test
@@ -58,8 +58,8 @@ jobs:
     - run: yarn prebuild --arch x64
 
     # Now install the arm version of the package and build for ARM. (Cross-compiling doesn't work otherwise - not sure why)
-    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.2.5/FoundationDB-7.2.5_arm64.pkg"
-    - run: sudo installer -pkg FoundationDB-7.2.5_arm64.pkg -target /
+    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.3.59/FoundationDB-7.3.59_arm64.pkg"
+    - run: sudo installer -pkg FoundationDB-7.3.59_arm64.pkg -target /
 
     - run: yarn prebuild --arch arm64
 
@@ -91,7 +91,7 @@ jobs:
 
   #   # Bleh - the 7.xx builds are currently missing one of the header files. More detail here:
   #   # https://forums.foundationdb.org/t/fdb-c-types-h-missing-in-windows-install-image/3817
-  #   - run: (new-object net.webclient).DownloadFile('https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-7.2.5-x64.msi', 'c:\foundationdb.msi')
+  #   - run: (new-object net.webclient).DownloadFile('https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-7.3.59-x64.msi', 'c:\foundationdb.msi')
   #   - run: dir c:\foundationdb.msi
   #   - run: msiexec /i c:\foundationdb.msi /quiet /passive /norestart /log install.log | Out-Null
 
@@ -136,8 +136,8 @@ jobs:
     - run: ls -R prebuilds
 
     # Ideally I shouldn't need this...
-    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-clients_7.2.5-1_amd64.deb"
-    - run: sudo dpkg -i foundationdb-clients_7.2.5-1_amd64.deb
+    - run: wget -nv "https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-clients_7.3.59-1_amd64.deb"
+    - run: sudo dpkg -i foundationdb-clients_7.3.59-1_amd64.deb
 
     # And I could just run the linux script last anyway.
     - run: yarn

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,11 +26,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - run: wget "https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-clients_7.2.5-1_amd64.deb"
-    - run: sudo dpkg -i foundationdb-clients_7.2.5-1_amd64.deb
+    - run: wget "https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-clients_7.3.59-1_amd64.deb"
+    - run: sudo dpkg -i foundationdb-clients_7.3.59-1_amd64.deb
     - run: sudo mkdir -p /var/lib/foundationdb/data
-    - run: wget "https://github.com/apple/foundationdb/releases/download/7.2.5/foundationdb-server_7.2.5-1_amd64.deb"
-    - run: sudo dpkg -i foundationdb-server_7.2.5-1_amd64.deb
+    - run: wget "https://github.com/apple/foundationdb/releases/download/7.3.59/foundationdb-server_7.3.59-1_amd64.deb"
+    - run: sudo dpkg -i foundationdb-server_7.3.59-1_amd64.deb
 
     - run: yarn
     - run: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HEAD
 
+# 2.0.2
+- Updated to support FoundationDB API version 730.
+  - This means node-foundationdb requires foundationdb-clients 7.3 (which is the only version currently supported by the FoundationDB team) or newer to build
+
 # 2.0.1
 
 - Added native support for apple silicon (arm64). This has been way too long coming. Thanks to everyone who contributed on [the github issue](https://github.com/josephg/node-foundationdb/issues/50). The library should automatically detect your computer's architecture and "just work". You will need to install a version of foundationdb which matches your computer's architecture.

--- a/lib/apiVersion.ts
+++ b/lib/apiVersion.ts
@@ -3,7 +3,7 @@ import nativeMod from './native'
 // To update:
 // - regenerate lib/opts.g.ts using scripts/gentsopts.ts
 // - re-run the test suite and binding test suite
-export const MAX_VERSION = 720
+export const MAX_VERSION = 730
 
 let apiVersion: number | null = null
 export const get = () => apiVersion

--- a/src/fdbversion.h
+++ b/src/fdbversion.h
@@ -24,6 +24,6 @@
 #ifndef FDB_NODE_VERSION_H
 #define FDB_NODE_VERSION_H
 
-#define FDB_API_VERSION 720
+#define FDB_API_VERSION 730
 
 #endif


### PR DESCRIPTION
This resolves #85. 

version `7.2` / `720` is [experimental](https://github.com/apple/foundationdb?tab=readme-ov-file#latest-stable-releases), for internal testing purposes only. Surely everyone is using v7.3 - which is the only fully-supported version of foundationdb.

Without this change, we cannot pass version 730 to setAPIVersion(). 

I've also updated the github workflows, readme and changelog to reflect this (and a new 2.0.2 release)
